### PR TITLE
Turn off libvirt namespace management of /dev/

### DIFF
--- a/augconf
+++ b/augconf
@@ -15,6 +15,9 @@ set /files/etc/libvirt/qemu.conf/user qemu
 set /files/etc/libvirt/qemu.conf/group qemu
 set /files/etc/libvirt/qemu.conf/dynamic_ownership 1
 
+# Workaround libvirt bug in /dev/ handling
+set /files/etc/libvirt/qemu.conf/namespaces
+
 # Have virtlogd log to stderr
 set /files/etc/libvirt/virtlogd.conf/log_outputs 2:stderr
 


### PR DESCRIPTION
Signed-off-by: Daniel P. Berrange <berrange@redhat.com>