### PR TITLE
Update libvirt base directory to fedora 27 to pull in latest changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:26
+FROM fedora:27
 
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 ENV container docker


### PR DESCRIPTION
Required for fixes related migration support.

There's a bug that prevents domains with vnc from being able to be migrated that the fedora27 libvirt fixes.

This is blocking the vnc/console kubevirt patch, https://github.com/kubevirt/kubevirt/pull/618