### PR TITLE
Install all virt-launcher dependencies in the libvirt image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,23 @@ FROM fedora:27
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 ENV container docker
 
+# Direct libvirt dependencies
 RUN dnf install -y \
   libvirt-daemon-kvm \
   libvirt-daemon-qemu \
   libvirt-client \
   selinux-policy selinux-policy-targeted \
   augeas && dnf clean all
+
+# Kubevirt launcher dependencies
+RUN dnf -y install \
+  socat \
+  genisoimage \
+  util-linux \
+  libcgroup-tools \
+  ethtool \
+  sudo && dnf -y clean all && \
+  test $(id -u qemu) = 107 # make sure that the qemu user really is 107
 
 COPY augconf /augconf
 RUN augtool -f /augconf

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,5 +2,5 @@
 set -x
 
 export LIBVIRT_VERSION=$(docker run --rm -it kubevirt/libvirt libvirtd --version | awk -F' ' '{print $NF}' | tr -d '[:space:]' )
-docker tag kubevirt/libvirt:latest kubevirt/libvirt:${LIBVIRT_VERSION}
+docker tag kubevirt/libvirt:latest kubevirt/libvirt:${LIBVIRT_VERSION}-bazel
 docker login -u="${DOCKER_USER}" -p="${DOCKER_PASS}" && docker push kubevirt/libvirt


### PR DESCRIPTION
Bazel does not allow RUN commands, make sure that all dependencies are
already there.

Signed-off-by: Roman Mohr <rmohr@redhat.com>