### PR TITLE
Only install x86 qemu binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,10 @@ FROM fedora:27
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 ENV container docker
 
-RUN dnf install -y \
+# nettle update is necessary for dnsmasq which is used by libvirt
+RUN dnf -y update nettle && \
+  dnf install -y \
   libvirt-daemon-kvm \
-  libvirt-daemon-qemu \
   libvirt-client \
   selinux-policy selinux-policy-targeted \
   augeas && dnf clean all


### PR DESCRIPTION
Don't install qemu binaries which we can't use (like ppc, mips, ...).
If /dev/kvm is available and they are present we have minute-long
libvirtd startup times on some hosts when it tries to detect the
capabilities for all those architectures.

Signed-off-by: Roman Mohr <rmohr@redhat.com>