### PR TITLE
Update libvirt to 4.2.0 (the latest we can get with non-rawhide fedora)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM fedora:28
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 ENV container docker
 
-# nettle update is necessary for dnsmasq which is used by libvirt
-RUN dnf -y update nettle && \
+RUN curl --output /etc/yum.repos.d/fedora-virt-preview.repo \
+  https://fedorapeople.org/groups/virt/virt-preview/fedora-virt-preview.repo && \
   dnf install -y \
   libvirt-daemon-kvm \
   libvirt-client \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:27
+FROM fedora:28
 
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 ENV container docker


### PR DESCRIPTION
To suppport a [libvirt update request in kubevirt](https://github.com/kubevirt/kubevirt/issues/956), I tested it with kubevirt's current master:

```
  k exec -ti virt-launcher-vm-ephemeral-2vhvb -c compute -- rpm -qa 'libvirt*'
libvirt-daemon-driver-storage-core-4.2.0-1.fc28.x86_64
libvirt-daemon-driver-storage-gluster-4.2.0-1.fc28.x86_64
libvirt-daemon-driver-storage-rbd-4.2.0-1.fc28.x86_64
libvirt-daemon-driver-storage-4.2.0-1.fc28.x86_64
libvirt-daemon-driver-secret-4.2.0-1.fc28.x86_64
libvirt-bash-completion-4.2.0-1.fc28.x86_64
libvirt-libs-4.2.0-1.fc28.x86_64
libvirt-daemon-4.2.0-1.fc28.x86_64
libvirt-daemon-driver-network-4.2.0-1.fc28.x86_64
libvirt-daemon-driver-storage-disk-4.2.0-1.fc28.x86_64
libvirt-daemon-driver-storage-iscsi-4.2.0-1.fc28.x86_64
libvirt-daemon-driver-storage-mpath-4.2.0-1.fc28.x86_64
libvirt-daemon-driver-storage-scsi-4.2.0-1.fc28.x86_64
libvirt-daemon-driver-storage-zfs-4.2.0-1.fc28.x86_64
libvirt-daemon-driver-interface-4.2.0-1.fc28.x86_64
libvirt-daemon-driver-nwfilter-4.2.0-1.fc28.x86_64
libvirt-daemon-kvm-4.2.0-1.fc28.x86_64
libvirt-daemon-driver-qemu-4.2.0-1.fc28.x86_64
libvirt-daemon-driver-storage-logical-4.2.0-1.fc28.x86_64
libvirt-daemon-driver-storage-sheepdog-4.2.0-1.fc28.x86_64
libvirt-daemon-driver-nodedev-4.2.0-1.fc28.x86_64
libvirt-client-4.2.0-1.fc28.x86_64
```

Fixes #16