### PR TITLE
Fix libvirt-preview repo, use version 4.9.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 FROM fedora:28
 
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
+ARG LIBVIRT_VERSION=4.9.0
 ENV container docker
 
 RUN curl --output /etc/yum.repos.d/fedora-virt-preview.repo \
-  https://fedorapeople.org/groups/virt/virt-preview/fedora-virt-preview.repo && \
+  https://copr.fedorainfracloud.org/coprs/g/virtmaint-sig/virt-preview/repo/fedora-28/group_virtmaint-sig-virt-preview-fedora-28.repo && \
   dnf install -y \
-  libvirt-daemon-kvm \
-  libvirt-client \
+  libvirt-daemon-kvm-$LIBVIRT_VERSION \
+  libvirt-client-$LIBVIRT_VERSION \
   selinux-policy selinux-policy-targeted \
   augeas && dnf clean all
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
 FROM fedora:28
 
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
-ARG LIBVIRT_VERSION=4.9.0
 ENV container docker
 
-RUN curl --output /etc/yum.repos.d/fedora-virt-preview.repo \
-  https://copr.fedorainfracloud.org/coprs/g/virtmaint-sig/virt-preview/repo/fedora-28/group_virtmaint-sig-virt-preview-fedora-28.repo && \
+RUN dnf install -y dnf-plugins-core && \
+  dnf copr enable -y @virtmaint-sig/virt-preview && \
   dnf install -y \
-  libvirt-daemon-kvm-$LIBVIRT_VERSION \
-  libvirt-client-$LIBVIRT_VERSION \
+  libvirt-daemon-kvm \
+  libvirt-client \
   selinux-policy selinux-policy-targeted \
   augeas && dnf clean all
 


### PR DESCRIPTION
This PR:
- Fixes the location of the virt-preview repo, see kubevirt/kubevirt#1425
- Adds a build argument which allows you to be explicit about the libvirt version you want
- Bumps the version to 4.9.0