### PR TITLE
Static install libvirt 5.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM fedora:28
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 ENV container docker
 
-ENV LIBVIRT_VERSION 5.1.0
+ENV LIBVIRT_VERSION 5.4.0
 
 RUN dnf install -y dnf-plugins-core && \
   dnf copr enable -y @virtmaint-sig/virt-preview && \
@@ -13,8 +13,8 @@ RUN dnf install -y dnf-plugins-core && \
     socat \
     genisoimage \
     selinux-policy selinux-policy-targeted \
-    augeas && \
-  dnf clean all
+    nftables \
+    augeas
 
 COPY augconf /augconf
 RUN augtool -f /augconf

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -3,7 +3,7 @@ FROM ppc64le/fedora:28
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 ENV container docker
 
-ENV LIBVIRT_VERSION 5.1.0
+ENV LIBVIRT_VERSION 5.4.0
 
 RUN dnf install -y dnf-plugins-core && \
   dnf copr enable -y @virtmaint-sig/virt-preview && \
@@ -13,8 +13,8 @@ RUN dnf install -y dnf-plugins-core && \
     socat \
     genisoimage \
     selinux-policy selinux-policy-targeted \
-    augeas && \
-  dnf clean all
+    nftables \
+    augeas
 
 COPY augconf /augconf
 RUN augtool -f /augconf

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker build -t kubevirt/libvirt:5.1.0 .
+docker build -t kubevirt/libvirt:5.4.0 .

--- a/publish.sh
+++ b/publish.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-docker tag kubevirt/libvirt:5.1.0 docker.io/kubevirt/libvirt:5.1.0
-docker push docker.io/kubevirt/libvirt:5.1.0
+docker tag kubevirt/libvirt:5.4.0 docker.io/kubevirt/libvirt:5.4.0
+docker push docker.io/kubevirt/libvirt:5.4.0


### PR DESCRIPTION
This PR is needed because we can't rebuild the image.
libvirt 5.0.0 packages are not longer exist under the virt repo.
Also the qemu pakcage that works with 5.0.0 don't exist any more.

This PR also installed the nftable package needed for okd 4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/libvirt/26)
<!-- Reviewable:end -->
