### PR TITLE
Drop socat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN dnf install -y dnf-plugins-core && \
   dnf install -y \
     libvirt-daemon-kvm-${LIBVIRT_VERSION} \
     libvirt-client-${LIBVIRT_VERSION} \
-    socat \
     genisoimage \
     selinux-policy selinux-policy-targeted \
     nftables \

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -10,7 +10,6 @@ RUN dnf install -y dnf-plugins-core && \
   dnf install -y \
     libvirt-daemon-kvm-${LIBVIRT_VERSION} \
     libvirt-client-${LIBVIRT_VERSION} \
-    socat \
     genisoimage \
     selinux-policy selinux-policy-targeted \
     nftables \


### PR DESCRIPTION
Now that we don't use socat for vnc and serial console connections
(see https://github.com/kubevirt/kubevirt/pull/2519) it can be dropped.

Signed-off-by: Arik Hadas <ahadas@redhat.com>