### PR TITLE
Minimize libvirt installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG QEMU_VERSION
 RUN dnf install -y dnf-plugins-core && \
     dnf copr enable -y @virtmaint-sig/for-kubevirt && \
     dnf install -y \
-      libvirt-daemon-kvm-${LIBVIRT_VERSION} \
+      libvirt-daemon-driver-qemu-${LIBVIRT_VERSION} \
       libvirt-client-${LIBVIRT_VERSION} \
       qemu-kvm-${QEMU_VERSION} \
       genisoimage \


### PR DESCRIPTION
This PR builds on top of https://github.com/kubevirt/libvirt/pull/36, which in turn builds on top of https://github.com/kubevirt/libvirt/pull/35, so it looks kinda scary but it's actually a single-line change! I'll rebase it once the other PRs have been accepted.

Test build: https://travis-ci.org/andreabolognani/kubevirt-libvirt/builds/613137209
Corresponding tag: `20191117.9e7b433` on https://hub.docker.com/repository/docker/andreabolognani/kubevirt-libvirt/tags

I have tested this by modifying my local copy of `kubevirt/kubevirt/WORKSPACE` to make it point to the aforementioned image, after which I was able to successfully bring up the cluster, start a guest and verify that KubeVirt it was indeed using a minimal libvirt installation instead of the full one:

```
$ make cluster-up && make cluster-sync
...
$ cluster-up/kubectl.sh create -f examples/vmi-nocloud.yaml 
virtualmachineinstance.kubevirt.io/vmi-nocloud created
$
$ cluster-up/kubectl.sh get pods
NAME                              READY   STATUS    RESTARTS   AGE
local-volume-provisioner-sttr4    1/1     Running   0          2m58s
virt-launcher-vmi-nocloud-f6srk   2/2     Running   0          33s
$ cluster-up/kubectl.sh exec -it -c compute virt-launcher-vmi-nocloud-f6srk /bin/bash
[root@vmi-nocloud /]# rpm -qa | grep libvirt
libvirt-client-5.0.0-2.fc30.x86_64
libvirt-libs-5.0.0-2.fc30.x86_64
libvirt-daemon-driver-storage-core-5.0.0-2.fc30.x86_64
libvirt-daemon-driver-network-5.0.0-2.fc30.x86_64
libvirt-bash-completion-5.0.0-2.fc30.x86_64
libvirt-daemon-5.0.0-2.fc30.x86_64
libvirt-daemon-driver-qemu-5.0.0-2.fc30.x86_64
[root@vmi-nocloud /]# exit
$
```

More thorough tests are definitely necessary :)