### PR TITLE
Fix uid mismatch on /dev/kvm

### DIFF
--- a/libvirtd.sh
+++ b/libvirtd.sh
@@ -16,6 +16,9 @@ mkdir /dev.container && {
   keep pts
   mount --rbind /dev/pts/ptmx /dev/ptmx
   # Use the container /dev/kvm if available
+  # Replace inherited permissions from host with ours, as we have a different passwd file
+  # we may use different uids, e.g. kvm on the host is not kvm within the container.
+  [[ -e /dev.container/kvm ]] && chown root:kvm /dev.container/kvm && chmod 660 /dev.container/kvm
   [[ -e /dev.container/kvm ]] && keep kvm
 }
 

--- a/libvirtd.sh
+++ b/libvirtd.sh
@@ -18,7 +18,7 @@ mkdir /dev.container && {
   # Use the container /dev/kvm if available
   # Replace inherited permissions from host with ours, as we have a different passwd file
   # we may use different uids, e.g. kvm on the host is not kvm within the container.
-  [[ -e /dev.container/kvm ]] && chown root:kvm /dev.container/kvm && chmod 660 /dev.container/kvm
+  [[ -e /dev.container/kvm ]] && chown root:kvm /dev.container/kvm && chmod 0666 /dev.container/kvm
   [[ -e /dev.container/kvm ]] && keep kvm
 }
 


### PR DESCRIPTION
Fix virt-install failing if host and container use different uids for the kvm user.
e.g. virt-install throwing `ValueError: Host does not support domain type kvm for virtualization type 'hvm' arch 'x86_64'`