### PR TITLE
Add CONTRIBUTING.md 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# Contributing to kubevirt/libvirt
+
+Welcome! As stated in the [README](README.md) this repository provides a simple
+container wrapping libvirtd for the kubevirt project.
+
+See [the KubeVirt contribution guide](
+https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md) for general
+information about how to contribute.


### PR DESCRIPTION
This is a copy of https://raw.githubusercontent.com/kubevirt/kubevirt/master/CONTRIBUTING.md,
I'd like to add it to this repo in order to fix the 'contributing guide'-link kubevirt-bot posts.

Signed-off-by: Klaus Frank <git@frank.fyi>