### PR TITLE
Add vhostuser support

### DIFF
--- a/augconf
+++ b/augconf
@@ -10,9 +10,7 @@ set /files/etc/libvirt/qemu.conf/vnc_listen 0.0.0.0
 set /files/etc/libvirt/qemu.conf/vnc_tls 0
 set /files/etc/libvirt/qemu.conf/vnc_sasl 0
 
-# Fixate user and group
-set /files/etc/libvirt/qemu.conf/user qemu
-set /files/etc/libvirt/qemu.conf/group qemu
+# Fixate ownership
 set /files/etc/libvirt/qemu.conf/dynamic_ownership 1
 set /files/etc/libvirt/qemu.conf/remember_owner 0
 


### PR DESCRIPTION
Libvirt will use the default user and group as "qemu" with uid/gid as 107. But inorder to share the vhostuser socket between qemu and openvswitch, a common group "hugetlbfs" has been created, so that in qemu as server mode, qemu will create the vhostuser socket with hugetlbfs group and ovs will be able to access the socket using the same group. For this, qemu.conf has to be updated with "group =  hugetlbfs". When the group is already added, edit in go requires to re-create the whole file. Instead, it would be apt to leave the default's as is. When user and group is not provided, qemu with id 107 will be used for both. The explicit configuration is removed to allow kubevirt to configure the group as required.