### PR TITLE
bump libvirt to 6.0.0 and drop PPC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: generic
 matrix:
   include:
   - os: linux
-  - os: linux-ppc64le
   - os: linux
     arch: arm64
 services:

--- a/config
+++ b/config
@@ -2,10 +2,10 @@
 
 IMAGE_NAME="kubevirt/libvirt"
 
-COPR_VERSION="av-8.1"
+COPR_VERSION="av-8.2"
 FEDORA_VERSION="31"
-LIBVIRT_VERSION="5.6.0-7.fc${FEDORA_VERSION}"
-QEMU_VERSION="4.1.0-15.fc${FEDORA_VERSION}"
+LIBVIRT_VERSION="6.0.0-16.fc${FEDORA_VERSION}"
+QEMU_VERSION="4.2.0-15.fc${FEDORA_VERSION}"
 
 # Keep this list in sync with that in .travis.yml
 MAIN_ARCH="ppc64le"

--- a/config
+++ b/config
@@ -8,5 +8,5 @@ LIBVIRT_VERSION="6.0.0-16.fc${FEDORA_VERSION}"
 QEMU_VERSION="4.2.0-15.fc${FEDORA_VERSION}"
 
 # Keep this list in sync with that in .travis.yml
-MAIN_ARCH="ppc64le"
-OTHER_ARCHES="x86_64 aarch64"
+MAIN_ARCH="x86_64"
+OTHER_ARCHES="aarch64"


### PR DESCRIPTION
In order to get latest bug fixes and features of libvirt, we should bump from
5.0 to 6.0. It would allow us to offload some of the tasks that are done in
virt-launcher to virt-handler and improve the overall security.

PPC support has been dropped from KubeVirt due to lack of CI. On top of
that, we don't have PPC libvirt builds available on our COPR repository.
Therefore, this patch removes PPC builds of the libvirt base image.
