### PR TITLE
Remove override of default user/group values

### DIFF
--- a/augconf
+++ b/augconf
@@ -10,9 +10,7 @@ set /files/etc/libvirt/qemu.conf/vnc_listen 0.0.0.0
 set /files/etc/libvirt/qemu.conf/vnc_tls 0
 set /files/etc/libvirt/qemu.conf/vnc_sasl 0
 
-# Fixate user and group
-set /files/etc/libvirt/qemu.conf/user qemu
-set /files/etc/libvirt/qemu.conf/group qemu
+# Fixate ownership
 set /files/etc/libvirt/qemu.conf/dynamic_ownership 1
 set /files/etc/libvirt/qemu.conf/remember_owner 0
 


### PR DESCRIPTION
By default, libvirt runs with user and group as 'qemu' with
gid and uid as 107. In case of DPDK deployments, in order to
share the vhostuser sockets, a common group will be used to
run both libvirt and openvswitch, which is 'hugetlbfs'.

In the current impementation, it is required to re-write
the qemu.conf file to change this configuration. Since the
default value of libvirt is 'qemu', removing this value will
not change any behavior. And it will allow kubevirt to append
group configuration, only for OvS-DPDK.

Signed-off-by: Saravanan KR <skramaja@redhat.com>