### PR TITLE
travis: Fix ci

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -16,6 +16,7 @@ for ARCH in ${TARGET_ARCHITECTURES}; do
     DOCKER_PLATFORM="linux/${ARCH}"
 
     docker buildx build \
+        --progress=plain \
         --load \
         --platform="${DOCKER_PLATFORM}" \
         --tag "${IMAGE_NAME}:${TAG}" \

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -16,6 +16,7 @@ docker login -u="${DOCKER_USER}" -p="${DOCKER_PASS}"
 # single step. The cached layers from the build step will be reused,
 # so ultimately this only assembles and pushes the manifest
 docker buildx build \
+    --progress=plain \
     --push \
     --platform="${DOCKER_PLATFORM}" \
     --tag "${IMAGE_NAME}:${TAG}" \


### PR DESCRIPTION
For some unknown reason 'docker buildx build' thinks travis env is
a tty, which causes way too much text output, which exceeds travis
max log size and kills the job.

Pass `--progress=plain` to the build command to get non-tty build
output