### PR TITLE
Add dependency to get the sysctl binary

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -17,6 +17,7 @@ RUN dnf install -y dnf-plugins-core && \
         selinux-policy selinux-policy-targeted \
         nftables \
         iptables \
+        procps-ng \
         augeas && \
     dnf update -y libgcrypt && \
     dnf clean all


### PR DESCRIPTION
sysctl is right now used in the kubevirt codebase to enable ipv6 forwarding.