### PR TITLE
Add findutils to have the find binary available

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -18,6 +18,7 @@ RUN dnf install -y dnf-plugins-core && \
         nftables \
         iptables \
         procps-ng \
+        findutils \
         augeas && \
     dnf update -y libgcrypt && \
     dnf clean all


### PR DESCRIPTION
A dependency which we use for some sanity checks from the tests.

Signed-off-by: Roman Mohr <rmohr@redhat.com>