### PR TITLE
Create compat symlink for QEMU

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -21,13 +21,15 @@ RUN dnf install -y dnf-plugins-core && \
         findutils \
         augeas && \
     dnf update -y libgcrypt && \
-    dnf clean all
+    dnf clean all && \
+    for arch in aarch64 ppc64 s390x x86_64; do \
+        qemu="/usr/bin/qemu-system-$arch"; \
+        test -f "$qemu" || continue; \
+        # Allow qemu to bind to privileged ports \
+        # From: https://github.com/kubevirt/kubevirt/pull/1138 \
+        setcap CAP_NET_BIND_SERVICE=+eip "$qemu" && \
+        break; \
+    done
 
 COPY augconf /augconf
 RUN augtool -f /augconf
-
-# Allow qemu to bind to privileged ports
-# From: https://github.com/kubevirt/kubevirt/pull/1138
-RUN for qemu in /usr/bin/qemu-system-*; do \
-        setcap CAP_NET_BIND_SERVICE=+eip $qemu; \
-    done

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -28,6 +28,9 @@ RUN dnf install -y dnf-plugins-core && \
         # Allow qemu to bind to privileged ports \
         # From: https://github.com/kubevirt/kubevirt/pull/1138 \
         setcap CAP_NET_BIND_SERVICE=+eip "$qemu" && \
+        # Needed for migration from old KubeVirt versions \
+        # https://github.com/kubevirt/kubevirt/issues/4629 \
+        ln -s "$qemu" /usr/libexec/qemu-kvm && \
         break; \
     done
 


### PR DESCRIPTION
Needed to migrate successfully from old KubeVirt versions, where the path to the QEMU binary was `/usr/libexec/qemu-kvm` instead of `/usr/bin/qemu-system-x86_64`.

https://github.com/kubevirt/kubevirt/issues/4629