### PR TITLE
Switch genisoimage to xorriso

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -13,7 +13,7 @@ RUN dnf install -y dnf-plugins-core && \
         qemu-kvm-@QEMU_BINARY_VERSION@ \
         seabios-bin-@SEABIOS_BINARY_VERSION@ \
         seavgabios-bin-@SEABIOS_BINARY_VERSION@ \
-        genisoimage \
+        xorriso \
         selinux-policy selinux-policy-targeted \
         nftables \
         iptables \


### PR DESCRIPTION
so we can backport https://github.com/kubevirt/kubevirt/pull/5806 to kubevirt release-0.36

Signed-off-by: Alexander Wels <awels@redhat.com>